### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/YZJ666/69b297ad-37e0-4676-99fa-426175600ead/dd6f6f4f-561a-46a8-a7c1-9227bb023c78/_apis/work/boardbadge/f46db45d-65a2-4208-8364-58e90493e132)](https://dev.azure.com/YZJ666/69b297ad-37e0-4676-99fa-426175600ead/_boards/board/t/dd6f6f4f-561a-46a8-a7c1-9227bb023c78/Microsoft.FeatureCategory)
 # 软件实训项目
 ## 放飞你的程序猿梦想
 ### 软件技术学习区，项目式学习，MIS开发实战，Web应用与开发，软件工程


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#252](https://dev.azure.com/YZJ666/69b297ad-37e0-4676-99fa-426175600ead/_workitems/edit/252). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.